### PR TITLE
Add all holidays in Guatemala.

### DIFF
--- a/src/DateTimeExtensions/WorkingDays/CultureStrategies/ES_GTHolidayStrategy.cs
+++ b/src/DateTimeExtensions/WorkingDays/CultureStrategies/ES_GTHolidayStrategy.cs
@@ -1,0 +1,102 @@
+using DateTimeExtensions.Common;
+
+namespace DateTimeExtensions.WorkingDays.CultureStrategies
+{
+    [Locale("es-GT")]
+    public class ES_GTHolidayStrategy : HolidayStrategyBase, IHolidayStrategy
+    {
+        public ES_GTHolidayStrategy()
+        {
+            this.InnerHolidays.Add(GlobalHolidays.NewYear);
+            this.InnerHolidays.Add(ChristianHolidays.MaundyThursday); // Jueves Santo
+            this.InnerHolidays.Add(ChristianHolidays.GoodFriday); // Viernes Santo
+            this.InnerHolidays.Add(ChristianHolidays.EasterSaturday); // Sábado de Gloria
+            this.InnerHolidays.Add(GlobalHolidays.InternationalWorkersDay); // Día del Trabajo
+            this.InnerHolidays.Add(MothersDay);
+            this.InnerHolidays.Add(ChristianHolidays.Assumption); // Feriado Ciudad Capital Guatemala
+            this.InnerHolidays.Add(ChristianHolidays.DayOfTheDead);
+            this.InnerHolidays.Add(ChristianHolidays.Christmas);
+            this.InnerHolidays.Add(ChristianHolidays.ChristmasEve);
+            this.InnerHolidays.Add(GlobalHolidays.NewYearsEve);
+            this.InnerHolidays.Add(IndependenceDay); // Día de la Independencia
+            this.InnerHolidays.Add(RevolutionDay); // Día de la Revolución
+            this.InnerHolidays.Add(ArmyDay); // Día del Ejército
+            this.InnerHolidays.Add(AllSaintsDay); // Día de Todos los Santos
+        }
+
+        private static Holiday _mothersDay;
+
+        private static Holiday _independenceDay;
+
+        private static Holiday _revolutionDay;
+
+        private static Holiday _armyDay;
+
+        private static Holiday _allSaintsDay;
+
+        public static Holiday MothersDay
+        {
+            get
+            {
+                if (_mothersDay == null)
+                {
+                    _mothersDay = new FixedHoliday("Día de la Madre", 5, 10);
+                }
+
+                return _mothersDay;
+            }
+        }
+
+        public static Holiday IndependenceDay
+        {
+            get
+            {
+                if (_independenceDay == null)
+                {
+                    _independenceDay = new FixedHoliday("Día de la Independencia", 9, 15);
+                }
+
+                return _independenceDay;
+            }
+        }
+
+        public static Holiday RevolutionDay
+        {
+            get
+            {
+                if (_revolutionDay == null)
+                {
+                    _revolutionDay = new FixedHoliday("Día de la Revolución", 10, 20);
+                }
+
+                return _revolutionDay;
+            }
+        }
+
+        public static Holiday ArmyDay
+        {
+            get
+            {
+                if (_armyDay == null)
+                {
+                    _armyDay = new FixedHoliday("Día del Ejercito", 6, 30);
+                }
+
+                return _armyDay;
+            }
+        }
+
+        public static Holiday AllSaintsDay
+        {
+            get
+            {
+                if (_allSaintsDay == null)
+                {
+                    _allSaintsDay = new FixedHoliday("Día de Todos los Santos", 11, 1);
+                }
+
+                return _allSaintsDay;
+            }
+        }
+    }
+}

--- a/tests/DateTimeExtensions.Tests/HolidaysTranslations/SpanishHolidaysNamesTest.cs
+++ b/tests/DateTimeExtensions.Tests/HolidaysTranslations/SpanishHolidaysNamesTest.cs
@@ -46,6 +46,15 @@ namespace DateTimeExtensions.Tests
             Assert.AreEqual(ChristianHolidays.Pentecost.Name, "Pentecostés");
             Assert.AreEqual(ChristianHolidays.PentecostMonday.Name, "Lunes de Pentecostés");
             Assert.AreEqual(GlobalHolidays.InternationalWorkersDay.Name, "Fiesta del Trabajo");
+
+            new CultureInfo("es-GT").SetCurrentUICultureInfo();
+            Assert.AreEqual("es-GT", CultureInfo.CurrentUICulture.Name);
+            Assert.AreEqual(ES_GTHolidayStrategy.ArmyDay.Name, "Día del Ejercito");
+            Assert.AreEqual(ES_GTHolidayStrategy.IndependenceDay.Name, "Día de la Independencia");
+            Assert.AreEqual(ES_GTHolidayStrategy.MothersDay.Name, "Día de la Madre");
+            Assert.AreEqual(ES_GTHolidayStrategy.RevolutionDay.Name, "Día de la Revolución");
+            Assert.AreEqual(ES_GTHolidayStrategy.AllSaintsDay.Name, "Día de Todos los Santos");
+
         }
     }
 }


### PR DESCRIPTION
Add all holidays in Guatemala.

#### PR Classification
New functionality to manage holidays in Guatemala

#### PR Summary
Add `ES_GTHolidayStrategy` class to define holidays in Guatmala and their names in spanish.

- `ES_GTHolidayStrategy.cs`: create class `ES_GTHolidayStrategy` and inherit from `HolidayStrategyBase` and implements specific holidays.
- `SpanishHolidaysNamesTest.cs`: Add assertions to validate holiday names for Guatemala.